### PR TITLE
Toggle cache to use Redis

### DIFF
--- a/docker-compose-redis.yml
+++ b/docker-compose-redis.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+  redis:
+    image: 'redis:6.0-rc3'
+    command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD}
+    volumes:
+      - redis_data:/data
+    ports:
+      - '6379:6379'
+    environment:
+      - REDIS_PASSWORD
+volumes:
+  redis_data:
+    driver: local

--- a/src/main/java/in/projecteka/consentmanager/common/cache/RedisCacheAdapter.java
+++ b/src/main/java/in/projecteka/consentmanager/common/cache/RedisCacheAdapter.java
@@ -23,10 +23,11 @@ public class RedisCacheAdapter implements CacheAdapter<String, String> {
     }
 
     @PreDestroy
-    public void preDestroy () {
+    public void preDestroy() {
         statefulConnection.close();
         redisClient.shutdown();
     }
+
     @Override
     public Mono<String> get(String key) {
         RedisReactiveCommands<String, String> redisCommands = statefulConnection.reactive();

--- a/src/main/java/in/projecteka/consentmanager/common/cache/RedisCacheAdapter.java
+++ b/src/main/java/in/projecteka/consentmanager/common/cache/RedisCacheAdapter.java
@@ -36,7 +36,9 @@ public class RedisCacheAdapter implements CacheAdapter<String, String> {
     @Override
     public Mono<Void> put(String key, String value) {
         RedisReactiveCommands<String, String> redisCommands = statefulConnection.reactive();
-        return redisCommands.set(key, value).doOnSuccess(s -> redisCommands.expire(key, 5 * 60L)).then();
+        return redisCommands.set(key, value)
+                .then(redisCommands.expire(key, 5 * 60L))
+                .then();
     }
 
     @Override

--- a/src/main/java/in/projecteka/consentmanager/common/cache/RedisOptions.java
+++ b/src/main/java/in/projecteka/consentmanager/common/cache/RedisOptions.java
@@ -19,4 +19,5 @@ import org.springframework.context.annotation.Configuration;
 public class RedisOptions {
     private String host;
     private int port;
+    private String password;
 }

--- a/src/main/java/in/projecteka/consentmanager/user/UserConfiguration.java
+++ b/src/main/java/in/projecteka/consentmanager/user/UserConfiguration.java
@@ -97,6 +97,7 @@ public class UserConfiguration {
         RedisURI redisUri = RedisURI.Builder.
                 redis(redisOptions.getHost())
                 .withPort(redisOptions.getPort())
+                .withPassword(redisOptions.getPassword())
                 .build();
         RedisClient redisClient = RedisClient.create(redisUri);
         return new RedisCacheAdapter(redisClient);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,7 +46,8 @@ consentmanager:
   redis:
     #Will not be used if cacheMethod is guava
     host: localhost
-    port: 6380
+    port: 6379
+    password: ${REDIS_PASSWORD}
 spring:
   rabbitmq:
     host: ${RABBITMQ_HOST}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,10 +42,10 @@ consentmanager:
       url: ${CONSENT_MANAGER_URL}
   linkservice:
     url: ${LINK_SERVICE_URL}
-  cacheMethod: guava
+  cacheMethod: redis
   redis:
     #Will not be used if cacheMethod is guava
-    host: localhost
+    host: ${REDIS_HOST}
     port: 6379
     password: ${REDIS_PASSWORD}
 spring:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,7 +42,8 @@ consentmanager:
       url: ${CONSENT_MANAGER_URL}
   linkservice:
     url: ${LINK_SERVICE_URL}
-  cacheMethod: redis
+  #Valid values are guava(for local), redis
+  cacheMethod: ${CACHE_METHOD}
   redis:
     #Will not be used if cacheMethod is guava
     host: ${REDIS_HOST}

--- a/src/test/java/in/projecteka/consentmanager/common/cache/RedisCacheAdapterTest.java
+++ b/src/test/java/in/projecteka/consentmanager/common/cache/RedisCacheAdapterTest.java
@@ -24,7 +24,7 @@ class RedisCacheAdapterTest {
     @Mock
     private RedisReactiveCommands<String,String> redisReactiveCommands;
     @InjectMocks
-    RedisCacheAdapter redisCacheAdapter;
+    private RedisCacheAdapter redisCacheAdapter;
 
     @BeforeEach
     public void init() {

--- a/src/test/java/in/projecteka/consentmanager/common/cache/RedisCacheAdapterTest.java
+++ b/src/test/java/in/projecteka/consentmanager/common/cache/RedisCacheAdapterTest.java
@@ -1,0 +1,70 @@
+package in.projecteka.consentmanager.common.cache;
+
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+class RedisCacheAdapterTest {
+    @Mock
+    private RedisClient redisClient;
+    @Mock
+    private StatefulRedisConnection<String, String> statefulConnection;
+    @Mock
+    private RedisReactiveCommands<String,String> redisReactiveCommands;
+    @InjectMocks
+    RedisCacheAdapter redisCacheAdapter;
+
+    @BeforeEach
+    public void init() {
+        MockitoAnnotations.initMocks(this);
+        when(redisClient.connect()).thenReturn(statefulConnection);
+        when(statefulConnection.reactive()).thenReturn(redisReactiveCommands);
+        redisCacheAdapter.postConstruct();
+    }
+
+    @Test
+    public void shouldGetFromRedisCache() {
+        String testKey = "foo";
+        String testValue = "bar";
+        when(redisReactiveCommands.get(testKey)).thenReturn(Mono.just(testValue));
+
+        String cachedValue = redisCacheAdapter.get(testKey).block();
+        Assert.assertEquals(testValue,cachedValue);
+        verify(statefulConnection).reactive();
+        verify(redisReactiveCommands).get(testKey);
+    }
+
+    @Test
+    public void shouldSetValueOnRedisCache() {
+        String testKey = "foo";
+        String testValue = "bar";
+        long expiration = 5 * 60L;
+        when(redisReactiveCommands.set(testKey,testValue)).thenReturn(Mono.just("OK"));
+        when(redisReactiveCommands.expire(testKey, expiration)).thenReturn(Mono.just(true));
+
+        StepVerifier.create(redisCacheAdapter.put(testKey, testValue)).verifyComplete();
+        verify(redisReactiveCommands).set(testKey,testValue);
+        verify(redisReactiveCommands).expire(testKey,expiration);
+    }
+
+    @Test
+    public void shouldInvalidate() {
+        String testKey = "foo";
+        when(redisReactiveCommands.expire(testKey, 0L)).thenReturn(Mono.just(true));
+
+        StepVerifier.create(redisCacheAdapter.invalidate(testKey)).verifyComplete();
+        verify(redisReactiveCommands).expire(testKey,0L);
+    }
+}


### PR DESCRIPTION
* Setup redis on dockernode.
* Have added  `REDIS_HOST` and `REDIS_PASSWORD` env values on docker-compose-consent-manager.yml on dockernode.
* Pushed the encrypted password on infra repo.
* Added basic tests. Toggle cache to use redis.