### PR TITLE
EKA-G8 | moved all the Gateway services properties lookup inside discoveryServiceClient

### DIFF
--- a/src/main/java/in/projecteka/consentmanager/ConsentManagerApplication.java
+++ b/src/main/java/in/projecteka/consentmanager/ConsentManagerApplication.java
@@ -7,7 +7,7 @@ import in.projecteka.consentmanager.clients.properties.OtpServiceProperties;
 import in.projecteka.consentmanager.common.cache.RedisOptions;
 import in.projecteka.consentmanager.consent.ConsentServiceProperties;
 import in.projecteka.consentmanager.dataflow.DataFlowConsentManagerProperties;
-import in.projecteka.consentmanager.link.discovery.GatewayServiceProperties;
+import in.projecteka.consentmanager.clients.properties.GatewayServiceProperties;
 import in.projecteka.consentmanager.user.JWTProperties;
 import in.projecteka.consentmanager.user.LockedServiceProperties;
 import in.projecteka.consentmanager.user.UserServiceProperties;

--- a/src/main/java/in/projecteka/consentmanager/clients/DiscoveryServiceClient.java
+++ b/src/main/java/in/projecteka/consentmanager/clients/DiscoveryServiceClient.java
@@ -1,5 +1,6 @@
 package in.projecteka.consentmanager.clients;
 
+import in.projecteka.consentmanager.clients.properties.GatewayServiceProperties;
 import in.projecteka.consentmanager.link.discovery.model.patient.request.PatientRequest;
 import in.projecteka.consentmanager.link.discovery.model.patient.response.PatientResponse;
 import lombok.AllArgsConstructor;
@@ -19,6 +20,7 @@ public class DiscoveryServiceClient {
     private static final String PATIENTS_CARE_CONTEXTS_DISCOVERY_URL_PATH = "/patients/care-contexts/discover";
     private final WebClient.Builder webClientBuilder;
     private final Supplier<Mono<String>> tokenGenerator;
+    private final GatewayServiceProperties gatewayServiceProperties;
 
     public Mono<PatientResponse> patientFor(PatientRequest request, String url, String hipId) {
         return tokenGenerator.get()
@@ -38,12 +40,12 @@ public class DiscoveryServiceClient {
                 .flatMap(responseSpec -> responseSpec.bodyToMono(PatientResponse.class));
     }
 
-    public Mono<Boolean> requestPatientFor(PatientRequest request, String url, String hipId) {
+    public Mono<Boolean> requestPatientFor(PatientRequest request, String hipId) {
         return tokenGenerator.get()
                 .flatMap(token ->
                         webClientBuilder.build()
                                 .post()
-                                .uri(url + PATIENTS_CARE_CONTEXTS_DISCOVERY_URL_PATH)
+                                .uri(gatewayServiceProperties.getBaseUrl() + PATIENTS_CARE_CONTEXTS_DISCOVERY_URL_PATH)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .header(AUTHORIZATION, token)
                                 .header("X-HIP-ID", hipId)
@@ -57,8 +59,7 @@ public class DiscoveryServiceClient {
                                 .onStatus(HttpStatus::is5xxServerError,
                                         clientResponse -> Mono.error(ClientError.networkServiceCallFailed()))
                                 .toBodilessEntity()
-                                //Make the timeout configurable
-                                .timeout(Duration.ofSeconds(2))
+                                .timeout(Duration.ofMillis(gatewayServiceProperties.getRequestTimeout()))
                 ).thenReturn(Boolean.TRUE);
     }
 }

--- a/src/main/java/in/projecteka/consentmanager/clients/DiscoveryServiceClient.java
+++ b/src/main/java/in/projecteka/consentmanager/clients/DiscoveryServiceClient.java
@@ -17,11 +17,12 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 @AllArgsConstructor
 public class DiscoveryServiceClient {
 
-    private static final String PATIENTS_CARE_CONTEXTS_DISCOVERY_URL_PATH = "/patients/care-contexts/discover";
+    private static final String PATIENTS_CARE_CONTEXTS_DISCOVERY_URL_PATH = "/care-contexts/discover";
     private final WebClient.Builder webClientBuilder;
     private final Supplier<Mono<String>> tokenGenerator;
     private final GatewayServiceProperties gatewayServiceProperties;
 
+    @Deprecated
     public Mono<PatientResponse> patientFor(PatientRequest request, String url, String hipId) {
         return tokenGenerator.get()
                 .map(token ->

--- a/src/main/java/in/projecteka/consentmanager/clients/properties/GatewayServiceProperties.java
+++ b/src/main/java/in/projecteka/consentmanager/clients/properties/GatewayServiceProperties.java
@@ -1,4 +1,4 @@
-package in.projecteka.consentmanager.link.discovery;
+package in.projecteka.consentmanager.clients.properties;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,5 +11,5 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 @ConstructorBinding
 public class GatewayServiceProperties {
     private final String baseUrl;
-    private final int responseTimeout;
+    private final int requestTimeout;
 }

--- a/src/main/java/in/projecteka/consentmanager/clients/properties/LinkServiceProperties.java
+++ b/src/main/java/in/projecteka/consentmanager/clients/properties/LinkServiceProperties.java
@@ -11,4 +11,5 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 @ConstructorBinding
 public class LinkServiceProperties {
     private final String url;
+    private final int txnTimeout;
 }

--- a/src/main/java/in/projecteka/consentmanager/link/LinkConfiguration.java
+++ b/src/main/java/in/projecteka/consentmanager/link/LinkConfiguration.java
@@ -6,6 +6,7 @@ import com.google.common.cache.LoadingCache;
 import in.projecteka.consentmanager.clients.DiscoveryServiceClient;
 import in.projecteka.consentmanager.clients.LinkServiceClient;
 import in.projecteka.consentmanager.clients.UserServiceClient;
+import in.projecteka.consentmanager.clients.properties.LinkServiceProperties;
 import in.projecteka.consentmanager.common.CentralRegistry;
 import in.projecteka.consentmanager.common.IdentityService;
 import in.projecteka.consentmanager.common.cache.CacheAdapter;
@@ -14,7 +15,7 @@ import in.projecteka.consentmanager.common.cache.RedisCacheAdapter;
 import in.projecteka.consentmanager.common.cache.RedisOptions;
 import in.projecteka.consentmanager.link.discovery.Discovery;
 import in.projecteka.consentmanager.link.discovery.DiscoveryRepository;
-import in.projecteka.consentmanager.link.discovery.GatewayServiceProperties;
+import in.projecteka.consentmanager.clients.properties.GatewayServiceProperties;
 import in.projecteka.consentmanager.link.link.Link;
 import in.projecteka.consentmanager.link.link.LinkRepository;
 import in.projecteka.consentmanager.user.UserServiceProperties;
@@ -48,8 +49,9 @@ public class LinkConfiguration {
 
     @Bean
     public DiscoveryServiceClient discoveryServiceClient(WebClient.Builder builder,
-                                                         CentralRegistry centralRegistry) {
-        return new DiscoveryServiceClient(builder, centralRegistry::authenticate);
+                                                         CentralRegistry centralRegistry,
+                                                         GatewayServiceProperties gatewayServiceProperties) {
+        return new DiscoveryServiceClient(builder, centralRegistry::authenticate, gatewayServiceProperties);
     }
 
     @Bean
@@ -64,9 +66,9 @@ public class LinkConfiguration {
                                CentralRegistry centralRegistry,
                                DiscoveryServiceClient discoveryServiceClient,
                                UserServiceClient userServiceClient,
-                               GatewayServiceProperties gatewayServiceProperties,
+                               LinkServiceProperties linkServiceProperties,
                                CacheAdapter<String,String> discoveryResults) {
-        return new Discovery(userServiceClient, discoveryServiceClient, discoveryRepository, centralRegistry, gatewayServiceProperties, discoveryResults);
+        return new Discovery(userServiceClient, discoveryServiceClient, discoveryRepository, centralRegistry, linkServiceProperties, discoveryResults);
     }
 
     @ConditionalOnProperty(value = "consentmanager.cacheMethod", havingValue = "guava", matchIfMissing = true)

--- a/src/main/java/in/projecteka/consentmanager/link/discovery/Discovery.java
+++ b/src/main/java/in/projecteka/consentmanager/link/discovery/Discovery.java
@@ -56,6 +56,7 @@ public class Discovery {
                 .map(Transformer::to);
     }
 
+    @Deprecated
     public Mono<DiscoveryResponse> patientFor(String userName,
                                               List<PatientIdentifier> unverifiedIdentifiers,
                                               String providerId,

--- a/src/main/java/in/projecteka/consentmanager/link/discovery/DiscoveryController.java
+++ b/src/main/java/in/projecteka/consentmanager/link/discovery/DiscoveryController.java
@@ -46,7 +46,7 @@ public class DiscoveryController {
                         discoveryRequest.getRequestId()));
     }
 
-    @PostMapping("/patients/care-contexts/discover")
+    @PostMapping("/care-contexts/discover")
     public Mono<DiscoveryResponse> discoverPatientCareContexts(@RequestBody @Valid DiscoveryRequest discoveryRequest) {
         return ReactiveSecurityContextHolder.getContext()
                 .map(securityContext -> (Caller) securityContext.getAuthentication().getPrincipal())
@@ -58,7 +58,7 @@ public class DiscoveryController {
                         discoveryRequest.getRequestId()));
     }
 
-    @PostMapping("/patients/care-contexts/on-discover")
+    @PostMapping("/care-contexts/on-discover")
     public Mono<Void> onDiscoverPatientCareContexts(@RequestBody @Valid DiscoveryResult discoveryResult){
         return discovery.onDiscoverPatientCareContexts(discoveryResult);
     }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -19,7 +19,7 @@ consentmanager:
     jwkUrl: http://host.docker.internal:8080/certs
   gatewayservice:
     baseUrl: http://host.docker.internal:8081
-    responseTimeout: 3
+    requestTimeout: 1000
   userservice:
     url: http://localhost:9000
     transactionPinDigitSize: 4
@@ -66,6 +66,7 @@ consentmanager:
       url: http://localhost:9000
   linkservice:
     url: http://localhost:9000
+    txnTimeout: 5000
 spring:
   rabbitmq:
     host: localhost

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ consentmanager:
     jwkUrl: ${CENTRAL_REGISTRY_JWK_URL}
   gatewayservice:
     baseUrl: ${GATEWAY_BASE_URL}
-    responseTimeout: ${GATEWAY_RESPONSE_TIMEOUT}
+    requestTimeout: ${GATEWAY_REQUEST_TIMEOUT}
   userservice:
     url: ${User_Service_Url}
     transactionPinDigitSize: ${TRANSACTION_PIN_DIGIT_SIZE}
@@ -62,6 +62,7 @@ consentmanager:
       url: ${CONSENT_MANAGER_URL}
   linkservice:
     url: ${LINK_SERVICE_URL}
+    txnTimeout: ${LINK_TRANSACTION_TIMEOUT}
   #Valid values are guava(for local), redis
   cacheMethod: ${CACHE_METHOD:guava}
   redis:

--- a/src/test/java/in/projecteka/consentmanager/clients/DiscoveryServiceClientTest.java
+++ b/src/test/java/in/projecteka/consentmanager/clients/DiscoveryServiceClientTest.java
@@ -1,6 +1,7 @@
 package in.projecteka.consentmanager.clients;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import in.projecteka.consentmanager.clients.properties.GatewayServiceProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -39,7 +40,8 @@ public class DiscoveryServiceClientTest {
     public void init() {
         MockitoAnnotations.initMocks(this);
         WebClient.Builder webClientBuilder = WebClient.builder().exchangeFunction(exchangeFunction);
-        discoveryServiceClient = new DiscoveryServiceClient(webClientBuilder, () -> Mono.just(string()));
+        GatewayServiceProperties serviceProperties = new GatewayServiceProperties("http://example.com", 1000);
+        discoveryServiceClient = new DiscoveryServiceClient(webClientBuilder, () -> Mono.just(string()), serviceProperties);
     }
 
     @Test

--- a/src/test/java/in/projecteka/consentmanager/clients/PatientServiceClientTest.java
+++ b/src/test/java/in/projecteka/consentmanager/clients/PatientServiceClientTest.java
@@ -35,7 +35,7 @@ class PatientServiceClientTest {
         MockitoAnnotations.initMocks(this);
         WebClient.Builder webClientBuilder = WebClient.builder()
                 .exchangeFunction(exchangeFunction);
-        LinkServiceProperties serviceProperties = new LinkServiceProperties("http://user-service/");
+        LinkServiceProperties serviceProperties = new LinkServiceProperties("http://user-service/", 1000);
         patientServiceClient = new PatientServiceClient(webClientBuilder, () -> Mono.just(string()), serviceProperties.getUrl());
     }
 

--- a/src/test/java/in/projecteka/consentmanager/link/discovery/DiscoveryTest.java
+++ b/src/test/java/in/projecteka/consentmanager/link/discovery/DiscoveryTest.java
@@ -9,7 +9,6 @@ import in.projecteka.consentmanager.clients.model.Address;
 import in.projecteka.consentmanager.clients.model.Provider;
 import in.projecteka.consentmanager.clients.model.Telecom;
 import in.projecteka.consentmanager.clients.model.User;
-import in.projecteka.consentmanager.clients.properties.GatewayServiceProperties;
 import in.projecteka.consentmanager.clients.properties.LinkServiceProperties;
 import in.projecteka.consentmanager.common.CentralRegistry;
 import in.projecteka.consentmanager.common.cache.CacheAdapter;
@@ -269,7 +268,6 @@ public class DiscoveryTest {
                         .type(patientIdentifier.getType().toString())
                         .value(patientIdentifier.getValue())
                         .build()).collect(Collectors.toList());
-        var patient = Patient.builder()
                 .id(user.getIdentifier())
                 .name(user.getName())
                 .gender(user.getGender())

--- a/src/test/java/in/projecteka/consentmanager/link/discovery/DiscoveryTest.java
+++ b/src/test/java/in/projecteka/consentmanager/link/discovery/DiscoveryTest.java
@@ -260,21 +260,8 @@ public class DiscoveryTest {
         var requestId = UUID.randomUUID();
         var patientId = string();
         var user = user().identifier("1").name("first name").phone("+91-9999999999").build();
-        var identifier = patientIdentifier().type("MOBILE").value("+91-9999999999").build();
         PatientIdentifier ncp1008 = patientIdentifierBuilder().type(PatientIdentifierType.MR).value("NCP1008").build();
         var unverifiedIdentifiers = Collections.singletonList(ncp1008);
-        var unverifiedIds = unverifiedIdentifiers.stream().map(patientIdentifier ->
-                in.projecteka.consentmanager.link.discovery.model.patient.request.Identifier.builder()
-                        .type(patientIdentifier.getType().toString())
-                        .value(patientIdentifier.getValue())
-                        .build()).collect(Collectors.toList());
-                .id(user.getIdentifier())
-                .name(user.getName())
-                .gender(user.getGender())
-                .yearOfBirth(user.getYearOfBirth())
-                .verifiedIdentifiers(of(identifier))
-                .unverifiedIdentifiers(unverifiedIds)
-                .build();
         UUID gatewayOnDiscoverRequestId = UUID.randomUUID();
         var gatewayResponse = GatewayResponse.builder().requestId(requestId.toString()).build();
         var patientInResponse = patientInResponse()

--- a/src/test/java/in/projecteka/consentmanager/link/discovery/DiscoveryTest.java
+++ b/src/test/java/in/projecteka/consentmanager/link/discovery/DiscoveryTest.java
@@ -1,5 +1,7 @@
 package in.projecteka.consentmanager.link.discovery;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import in.projecteka.consentmanager.clients.ClientError;
 import in.projecteka.consentmanager.clients.DiscoveryServiceClient;
 import in.projecteka.consentmanager.clients.UserServiceClient;
@@ -7,11 +9,15 @@ import in.projecteka.consentmanager.clients.model.Address;
 import in.projecteka.consentmanager.clients.model.Provider;
 import in.projecteka.consentmanager.clients.model.Telecom;
 import in.projecteka.consentmanager.clients.model.User;
+import in.projecteka.consentmanager.clients.properties.GatewayServiceProperties;
+import in.projecteka.consentmanager.clients.properties.LinkServiceProperties;
 import in.projecteka.consentmanager.common.CentralRegistry;
 import in.projecteka.consentmanager.common.cache.CacheAdapter;
 import in.projecteka.consentmanager.link.discovery.model.patient.request.Patient;
 import in.projecteka.consentmanager.link.discovery.model.patient.request.PatientIdentifier;
 import in.projecteka.consentmanager.link.discovery.model.patient.request.PatientIdentifierType;
+import in.projecteka.consentmanager.link.discovery.model.patient.response.DiscoveryResult;
+import in.projecteka.consentmanager.link.discovery.model.patient.response.GatewayResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -37,6 +43,7 @@ import static in.projecteka.consentmanager.link.discovery.TestBuilders.string;
 import static in.projecteka.consentmanager.link.discovery.TestBuilders.telecom;
 import static in.projecteka.consentmanager.link.discovery.TestBuilders.user;
 import static java.util.List.of;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -56,8 +63,7 @@ public class DiscoveryTest {
     @Mock
     DiscoveryRepository discoveryRepository;
 
-    @Mock
-    GatewayServiceProperties gatewayServiceProperties;
+    LinkServiceProperties linkServiceProperties = new LinkServiceProperties("http://tmc.gov.in/ncg-gateway", 1000);
 
     @Mock
     CacheAdapter<String,String> discoveryResults;
@@ -74,7 +80,7 @@ public class DiscoveryTest {
                 discoveryServiceClient,
                 discoveryRepository,
                 centralRegistry,
-                gatewayServiceProperties,
+                linkServiceProperties,
                 discoveryResults);
         var address = address().use("work").build();
         var telecommunication = telecom().use("work").build();
@@ -102,7 +108,7 @@ public class DiscoveryTest {
                                     discoveryServiceClient,
                                     discoveryRepository,
                                     centralRegistry,
-                                    gatewayServiceProperties,
+                                    linkServiceProperties,
                                     discoveryResults);
         var address = address().use("work").build();
         var telecom = telecom().use("work").build();
@@ -168,7 +174,7 @@ public class DiscoveryTest {
                 discoveryServiceClient,
                 discoveryRepository,
                 centralRegistry,
-                gatewayServiceProperties,
+                linkServiceProperties,
                 discoveryResults);
         Address address = address().use("work").build();
         Telecom telecom = telecom().use("work").build();
@@ -208,7 +214,7 @@ public class DiscoveryTest {
                 discoveryServiceClient,
                 discoveryRepository,
                 centralRegistry,
-                gatewayServiceProperties,
+                linkServiceProperties,
                 discoveryResults);
 
         when(discoveryRepository.getIfPresent(requestId)).thenReturn(Mono.just(transactionId.toString()));
@@ -231,7 +237,7 @@ public class DiscoveryTest {
                 discoveryServiceClient,
                 discoveryRepository,
                 centralRegistry,
-                gatewayServiceProperties,
+                linkServiceProperties,
                 discoveryResults);
         var address = address().use("work").build();
         var telecommunication = telecom().use("work").build();
@@ -247,4 +253,68 @@ public class DiscoveryTest {
         StepVerifier.create(discovery.providersFrom("Max"))
                 .verifyComplete();
     }
+
+    @Test
+    public void patientForGivenHIPIdAndPatientId() throws JsonProcessingException {
+        var hipId = string();
+        var transactionId = UUID.randomUUID();
+        var requestId = UUID.randomUUID();
+        var patientId = string();
+        var user = user().identifier("1").name("first name").phone("+91-9999999999").build();
+        var identifier = patientIdentifier().type("MOBILE").value("+91-9999999999").build();
+        PatientIdentifier ncp1008 = patientIdentifierBuilder().type(PatientIdentifierType.MR).value("NCP1008").build();
+        var unverifiedIdentifiers = Collections.singletonList(ncp1008);
+        var unverifiedIds = unverifiedIdentifiers.stream().map(patientIdentifier ->
+                in.projecteka.consentmanager.link.discovery.model.patient.request.Identifier.builder()
+                        .type(patientIdentifier.getType().toString())
+                        .value(patientIdentifier.getValue())
+                        .build()).collect(Collectors.toList());
+        var patient = Patient.builder()
+                .id(user.getIdentifier())
+                .name(user.getName())
+                .gender(user.getGender())
+                .yearOfBirth(user.getYearOfBirth())
+                .verifiedIdentifiers(of(identifier))
+                .unverifiedIdentifiers(unverifiedIds)
+                .build();
+        UUID gatewayOnDiscoverRequestId = UUID.randomUUID();
+        var gatewayResponse = GatewayResponse.builder().requestId(requestId.toString()).build();
+        var patientInResponse = patientInResponse()
+                .display("John Doe")
+                .referenceNumber("123")
+                .matchedBy(of())
+                .careContexts(of())
+                .build();
+
+        DiscoveryResult discoveryResult = DiscoveryResult.builder()
+                .patient(patientInResponse)
+                .requestId(gatewayOnDiscoverRequestId)
+                .transactionId(transactionId)
+                .resp(gatewayResponse)
+                .build();
+        String discoveryResultInCache = new ObjectMapper().writeValueAsString(discoveryResult);
+        when(discoveryRepository.getIfPresent(requestId)).thenReturn(Mono.empty());
+        when(userServiceClient.userOf(eq(patientId))).thenReturn(Mono.just(user));
+        when(discoveryServiceClient.requestPatientFor(any(), eq(hipId)))
+                .thenReturn(Mono.just(true));
+        when(discoveryResults.get(requestId.toString())).thenReturn(Mono.just(discoveryResultInCache));
+        when(discoveryRepository.insert(hipId, patientId, transactionId, requestId)).thenReturn(Mono.empty());
+        var discoveryResponse = discoveryResponse()
+                .patient(patientInResponse)
+                .transactionId(transactionId)
+                .build();
+        var discovery = new Discovery(userServiceClient,
+                discoveryServiceClient,
+                discoveryRepository,
+                centralRegistry,
+                linkServiceProperties,
+                discoveryResults);
+        StepVerifier.create(
+                discovery.patientInHIP(patientId, unverifiedIdentifiers, hipId, transactionId, requestId)
+                        .subscriberContext(cxt -> cxt.put(AUTHORIZATION, string())))
+                .expectNext(discoveryResponse)
+                .verifyComplete();
+    }
+
+
 }

--- a/src/test/java/in/projecteka/consentmanager/link/discovery/DiscoveryUserJourneyTest.java
+++ b/src/test/java/in/projecteka/consentmanager/link/discovery/DiscoveryUserJourneyTest.java
@@ -219,7 +219,7 @@ public class DiscoveryUserJourneyTest {
                 new Error(ErrorCode.NO_RESULT_FROM_GATEWAY,"Didn't receive any result from Gateway"));
         var errorResponseJson = OBJECT_MAPPER.writeValueAsString(errorResponse);
         webTestClient.post()
-                .uri("/patients/care-contexts/discover")
+                .uri("/care-contexts/discover")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.AUTHORIZATION, token)
@@ -260,7 +260,7 @@ public class DiscoveryUserJourneyTest {
         when(discoveryServiceClient.requestPatientFor(any(), eq("12345"))).thenReturn(Mono.just(true));
         when(discoveryResults.get(any())).thenReturn(Mono.just(patientResponse));
         webTestClient.post()
-                .uri("/patients/care-contexts/discover")
+                .uri("/care-contexts/discover")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.AUTHORIZATION, token)
@@ -301,7 +301,7 @@ public class DiscoveryUserJourneyTest {
                 new Error(ErrorCode.NO_PATIENT_FOUND,"Could not find patient information"));
         var errorResponseJson = OBJECT_MAPPER.writeValueAsString(errorResponse);
         webTestClient.post()
-                .uri("/patients/care-contexts/discover")
+                .uri("/care-contexts/discover")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.AUTHORIZATION, token)
@@ -338,7 +338,7 @@ public class DiscoveryUserJourneyTest {
                 new Error(ErrorCode.NO_PATIENT_FOUND,"Could not find patient information"));
         var errorResponseJson = OBJECT_MAPPER.writeValueAsString(errorResponse);
         webTestClient.post()
-                .uri("/patients/care-contexts/discover")
+                .uri("/care-contexts/discover")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.AUTHORIZATION, token)
@@ -355,7 +355,7 @@ public class DiscoveryUserJourneyTest {
         var patientDiscoveryResult = TestBuilders.discoveryResult().build();
         when(authenticator.verify(token)).thenReturn(Mono.just(new Caller("test-user-id", false)));
         webTestClient.post()
-                .uri("/patients/care-contexts/on-discover")
+                .uri("/care-contexts/on-discover")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.AUTHORIZATION, token)
@@ -381,7 +381,7 @@ public class DiscoveryUserJourneyTest {
                 .build();
         when(authenticator.verify(token)).thenReturn(Mono.just(new Caller("test-user-id", false)));
         webTestClient.post()
-                .uri("/patients/care-contexts/on-discover")
+                .uri("/care-contexts/on-discover")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.AUTHORIZATION, token)
@@ -395,7 +395,7 @@ public class DiscoveryUserJourneyTest {
         var token = string();
         when(authenticator.verify(token)).thenReturn(Mono.just(new Caller("test-user-id", false)));
         webTestClient.post()
-                .uri("/patients/care-contexts/on-discover")
+                .uri("/care-contexts/on-discover")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.AUTHORIZATION, token)

--- a/src/test/java/in/projecteka/consentmanager/link/discovery/DiscoveryUserJourneyTest.java
+++ b/src/test/java/in/projecteka/consentmanager/link/discovery/DiscoveryUserJourneyTest.java
@@ -213,7 +213,7 @@ public class DiscoveryUserJourneyTest {
         when(userServiceClient.userOf(userId)).thenReturn(Mono.just(TestBuilders.user().build()));
         when(discoveryRepository.getIfPresent(any())).thenReturn(Mono.empty());
         when(discoveryRepository.insert(anyString(), anyString(), any(), any())).thenReturn(Mono.empty());
-        when(discoveryServiceClient.requestPatientFor(any(), eq("http://tmc.gov.in/ncg-gateway"), eq("12345"))).thenReturn(Mono.just(true));
+        when(discoveryServiceClient.requestPatientFor(any(), eq("12345"))).thenReturn(Mono.just(true));
         when(discoveryResults.get(any())).thenReturn(Mono.empty());
         var errorResponse = new ErrorRepresentation(
                 new Error(ErrorCode.NO_RESULT_FROM_GATEWAY,"Didn't receive any result from Gateway"));
@@ -257,7 +257,7 @@ public class DiscoveryUserJourneyTest {
         when(userServiceClient.userOf(userId)).thenReturn(Mono.just(TestBuilders.user().build()));
         when(discoveryRepository.getIfPresent(any())).thenReturn(Mono.empty());
         when(discoveryRepository.insert(anyString(), anyString(), any(), any())).thenReturn(Mono.empty());
-        when(discoveryServiceClient.requestPatientFor(any(), eq("http://tmc.gov.in/ncg-gateway"), eq("12345"))).thenReturn(Mono.just(true));
+        when(discoveryServiceClient.requestPatientFor(any(), eq("12345"))).thenReturn(Mono.just(true));
         when(discoveryResults.get(any())).thenReturn(Mono.just(patientResponse));
         webTestClient.post()
                 .uri("/patients/care-contexts/discover")
@@ -295,7 +295,7 @@ public class DiscoveryUserJourneyTest {
         when(userServiceClient.userOf(userId)).thenReturn(Mono.just(TestBuilders.user().build()));
         when(discoveryRepository.getIfPresent(any())).thenReturn(Mono.empty());
         when(discoveryRepository.insert(anyString(), anyString(), any(), any())).thenReturn(Mono.empty());
-        when(discoveryServiceClient.requestPatientFor(any(), eq("http://tmc.gov.in/ncg-gateway"), eq("12345"))).thenReturn(Mono.just(true));
+        when(discoveryServiceClient.requestPatientFor(any(), eq("12345"))).thenReturn(Mono.just(true));
         when(discoveryResults.get(any())).thenReturn(Mono.just(patientResponse));
         var errorResponse = new ErrorRepresentation(
                 new Error(ErrorCode.NO_PATIENT_FOUND,"Could not find patient information"));
@@ -332,7 +332,7 @@ public class DiscoveryUserJourneyTest {
         when(userServiceClient.userOf(userId)).thenReturn(Mono.just(TestBuilders.user().build()));
         when(discoveryRepository.getIfPresent(any())).thenReturn(Mono.empty());
         when(discoveryRepository.insert(anyString(), anyString(), any(), any())).thenReturn(Mono.empty());
-        when(discoveryServiceClient.requestPatientFor(any(), eq("http://tmc.gov.in/ncg-gateway"), eq("12345"))).thenReturn(Mono.just(true));
+        when(discoveryServiceClient.requestPatientFor(any(), eq("12345"))).thenReturn(Mono.just(true));
         when(discoveryResults.get(any())).thenReturn(Mono.just(patientResponse));
         var errorResponse = new ErrorRepresentation(
                 new Error(ErrorCode.NO_PATIENT_FOUND,"Could not find patient information"));

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -26,5 +26,8 @@ consentmanager:
       url: http://localhost:8000
   gatewayservice:
     baseUrl: http://tmc.gov.in/ncg-gateway
-    responseTimeout: 3
+    requestTimeout: 1000
+  linkservice:
+    url: http://localhost:9000
+    txnTimeout: 5000
   cacheMethod: guava


### PR DESCRIPTION
Introduced and externalized requestTimeout and txnTimeout. Updated for signature change, refactoring. Also moved GatewayProperties to client/properties package