### PR TITLE
BUG_FIX | Fix bug where CM responds 500 on already existing user

### DIFF
--- a/src/main/java/in/projecteka/consentmanager/user/UserRepository.java
+++ b/src/main/java/in/projecteka/consentmanager/user/UserRepository.java
@@ -27,7 +27,7 @@ public class UserRepository {
 
     public Mono<User> userWith(String userName) {
         return Mono.create(monoSink -> dbClient.preparedQuery(SELECT_PATIENT)
-                .execute(Tuple.of(userName),
+                .execute(Tuple.of(userName.toLowerCase()),
                         handler -> {
                             if (handler.failed()) {
                                 logger.error(handler.cause().getMessage(), handler.cause());


### PR DESCRIPTION
**`BUG`**: When creating a new account if a CM id (already existing) is not provided in lower case then CM responds with 500 rather than responding with `ERROR CODE 1019` (User already exists).