### PR TITLE
EKA-G18 | Adds on-init call back API

### DIFF
--- a/src/main/java/in/projecteka/consentmanager/clients/model/PatientLinkReferenceResult.java
+++ b/src/main/java/in/projecteka/consentmanager/clients/model/PatientLinkReferenceResult.java
@@ -1,0 +1,33 @@
+package in.projecteka.consentmanager.clients.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import in.projecteka.consentmanager.link.discovery.model.patient.response.GatewayResponse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
+
+import javax.validation.constraints.NotNull;
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(Include.NON_NULL)
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Data
+public class PatientLinkReferenceResult {
+    private UUID requestId;
+    private String timestamp;
+    private Link link;
+    private RespError error;
+    @NotNull
+    private GatewayResponse resp;
+
+    public boolean hasResponseId() {
+        return (resp != null) && !StringUtils.isEmpty(resp.getRequestId());
+    }
+}

--- a/src/main/java/in/projecteka/consentmanager/link/LinkConfiguration.java
+++ b/src/main/java/in/projecteka/consentmanager/link/LinkConfiguration.java
@@ -46,15 +46,13 @@ public class LinkConfiguration {
                      CentralRegistry centralRegistry,
                      GatewayServiceProperties gatewayServiceProperties,
                      LinkServiceProperties serviceProperties,
-                     CacheAdapter<String, String> linkResults,
-                     CacheAdapter<String, String> patientLinkReferenceResults) {
+                     CacheAdapter<String, String> linkResults) {
         return new Link(
                 new LinkServiceClient(builder, centralRegistry, gatewayServiceProperties),
                 linkRepository,
                 centralRegistry,
                 serviceProperties,
-                linkResults,
-                patientLinkReferenceResults);
+                linkResults);
      }
 
     @Bean
@@ -82,7 +80,7 @@ public class LinkConfiguration {
     }
 
     @ConditionalOnProperty(value = "consentmanager.cacheMethod", havingValue = "guava", matchIfMissing = true)
-    @Bean({"discoveryResults", "linkResults", "patientLinkReferenceResults"})
+    @Bean({"discoveryResults", "linkResults"})
     public CacheAdapter<String, String> createLoadingCacheAdapter() {
         return new LoadingCacheAdapter(createSessionCache(5));
     }
@@ -99,7 +97,7 @@ public class LinkConfiguration {
     }
 
     @ConditionalOnProperty(value = "consentmanager.cacheMethod", havingValue = "redis")
-    @Bean({"discoveryResults", "linkResults", "patientLinkReferenceResults"})
+    @Bean({"discoveryResults", "linkResults"})
     public CacheAdapter<String, String> createRedisCacheAdapter(RedisClient redisClient) {
         return new RedisCacheAdapter(redisClient, 5);
     }

--- a/src/main/java/in/projecteka/consentmanager/link/LinkConfiguration.java
+++ b/src/main/java/in/projecteka/consentmanager/link/LinkConfiguration.java
@@ -46,14 +46,16 @@ public class LinkConfiguration {
                      CentralRegistry centralRegistry,
                      GatewayServiceProperties gatewayServiceProperties,
                      LinkServiceProperties serviceProperties,
-                     CacheAdapter<String, String> linkResults) {
+                     CacheAdapter<String, String> linkResults,
+                     CacheAdapter<String, String> patientLinkReferenceResults) {
         return new Link(
                 new LinkServiceClient(builder, centralRegistry, gatewayServiceProperties),
                 linkRepository,
                 centralRegistry,
                 serviceProperties,
-                linkResults);
-    }
+                linkResults,
+                patientLinkReferenceResults);
+     }
 
     @Bean
     public DiscoveryServiceClient discoveryServiceClient(WebClient.Builder builder,
@@ -80,7 +82,7 @@ public class LinkConfiguration {
     }
 
     @ConditionalOnProperty(value = "consentmanager.cacheMethod", havingValue = "guava", matchIfMissing = true)
-    @Bean({"discoveryResults", "linkResults"})
+    @Bean({"discoveryResults", "linkResults", "patientLinkReferenceResults"})
     public CacheAdapter<String, String> createLoadingCacheAdapter() {
         return new LoadingCacheAdapter(createSessionCache(5));
     }
@@ -97,7 +99,7 @@ public class LinkConfiguration {
     }
 
     @ConditionalOnProperty(value = "consentmanager.cacheMethod", havingValue = "redis")
-    @Bean({"discoveryResults", "linkResults"})
+    @Bean({"discoveryResults", "linkResults", "patientLinkReferenceResults"})
     public CacheAdapter<String, String> createRedisCacheAdapter(RedisClient redisClient) {
         return new RedisCacheAdapter(redisClient, 5);
     }

--- a/src/main/java/in/projecteka/consentmanager/link/link/Link.java
+++ b/src/main/java/in/projecteka/consentmanager/link/link/Link.java
@@ -42,7 +42,6 @@ public class Link {
     private final CentralRegistry centralRegistry;
     private final LinkServiceProperties serviceProperties;
     private final CacheAdapter<String, String> linkResults;
-    private final CacheAdapter<String,String> patientLinkReferenceResults;
 
     private static final Logger logger = LoggerFactory.getLogger(Link.class);
 
@@ -143,7 +142,7 @@ public class Link {
 
     public Mono<Void> onLinkCareContexts(PatientLinkReferenceResult patientLinkReferenceResult) {
         if(patientLinkReferenceResult.hasResponseId()) {
-            return patientLinkReferenceResults.put(patientLinkReferenceResult.getResp().getRequestId(), serializeLinkReferenceResultFromHIP(patientLinkReferenceResult));
+            return linkResults.put(patientLinkReferenceResult.getResp().getRequestId(), serializeLinkReferenceResultFromHIP(patientLinkReferenceResult));
         }
         logger.error("[Link] Received a patient link reference response from Gateway without original request Id mentioned.{}", patientLinkReferenceResult.getRequestId());
         return Mono.error(ClientError.unprocessableEntity());

--- a/src/main/java/in/projecteka/consentmanager/link/link/LinkController.java
+++ b/src/main/java/in/projecteka/consentmanager/link/link/LinkController.java
@@ -1,6 +1,7 @@
 package in.projecteka.consentmanager.link.link;
 
 import in.projecteka.consentmanager.clients.model.PatientLinkReferenceResponse;
+import in.projecteka.consentmanager.clients.model.PatientLinkReferenceResult;
 import in.projecteka.consentmanager.clients.model.PatientLinkRequest;
 import in.projecteka.consentmanager.clients.model.PatientLinkResponse;
 import in.projecteka.consentmanager.common.Caller;
@@ -52,6 +53,11 @@ public class LinkController {
     @GetMapping("internal/patients/{username}/links")
     public Mono<PatientLinksResponse> getLinkedCareContextInternal(@PathVariable String username) {
         return link.getLinkedCareContexts(username);
+    }
+
+    @PostMapping("/v1/links/link/on-init")
+    public Mono<Void> onLinkCareContexts(@RequestBody PatientLinkReferenceResult patientLinkReferenceResult) {
+        return link.onLinkCareContexts(patientLinkReferenceResult);
     }
 
     /**

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -18,7 +18,7 @@ consentmanager:
     url: http://host.docker.internal:8080
     jwkUrl: http://host.docker.internal:8080/certs
   gatewayservice:
-    baseUrl: http://host.docker.internal:8081
+    baseUrl: http://host.docker.internal:8081/v1
     requestTimeout: 1000
   userservice:
     url: http://localhost:9000

--- a/src/test/java/in/projecteka/consentmanager/link/link/LinkTest.java
+++ b/src/test/java/in/projecteka/consentmanager/link/link/LinkTest.java
@@ -59,9 +59,6 @@ class LinkTest {
     @Mock
     private CacheAdapter<String, String> linkResults;
 
-    @Mock
-    private CacheAdapter<String,String> patientLinkReferenceResults;
-
     @BeforeEach
     public void setUp() {
         initMocks(this);
@@ -70,7 +67,7 @@ class LinkTest {
     @Test
     public void createsLinkReference() {
         LinkServiceProperties linkServiceProperties = new LinkServiceProperties("http://tmc.gov.in/ncg-gateway", 1000);
-        var link = new Link(linkServiceClient, linkRepository, clientRegistryClient, linkServiceProperties, linkResults, patientLinkReferenceResults);
+        var link = new Link(linkServiceClient, linkRepository, clientRegistryClient, linkServiceProperties, linkResults);
         var address = address().use("work").build();
         var telecommunication = telecom().use("work").build();
         String providerUrl = "http://localhost:8001";
@@ -112,7 +109,7 @@ class LinkTest {
     public void shouldGetSystemUrlForOfficialIdentifier() {
         var token = string();
         LinkServiceProperties linkServiceProperties = new LinkServiceProperties("http://tmc.gov.in/ncg-gateway", 1000);
-        var link = new Link(linkServiceClient, linkRepository, clientRegistryClient, linkServiceProperties, linkResults, patientLinkReferenceResults);
+        var link = new Link(linkServiceClient, linkRepository, clientRegistryClient, linkServiceProperties, linkResults);
         var address = address().use("work").build();
         var telecommunication = telecom().use("work").build();
         String providerUrl = "http://localhost:8001";
@@ -159,7 +156,7 @@ class LinkTest {
     @Test
     public void shouldGetErrorWhenProviderUrlIsEmpty() {
         LinkServiceProperties linkServiceProperties = new LinkServiceProperties("http://tmc.gov.in/ncg-gateway", 1000);
-        var link = new Link(linkServiceClient, linkRepository, clientRegistryClient, linkServiceProperties, linkResults, patientLinkReferenceResults);
+        var link = new Link(linkServiceClient, linkRepository, clientRegistryClient, linkServiceProperties, linkResults);
         var address = address().use("work").build();
         var telecommunication = telecom().use("work").build();
         var provider =
@@ -191,7 +188,7 @@ class LinkTest {
     @Test
     public void linksPatientsCareContexts() {
         LinkServiceProperties linkServiceProperties = new LinkServiceProperties("http://tmc.gov.in/ncg-gateway", 1000);
-        var link = new Link(linkServiceClient, linkRepository, clientRegistryClient, linkServiceProperties, linkResults, patientLinkReferenceResults);
+        var link = new Link(linkServiceClient, linkRepository, clientRegistryClient, linkServiceProperties, linkResults);
         var address = address().use("work").build();
         var telecommunication = telecom().use("work").build();
         String providerUrl = "http://localhost:8001";
@@ -262,7 +259,7 @@ class LinkTest {
         when(linkRepository.getLinkedCareContextsForAllHip(patientId)).thenReturn(Mono.just(patientLinks));
         when(clientRegistryClient.providerWith(eq(hipId))).thenReturn(Mono.just(provider));
         LinkServiceProperties linkServiceProperties = new LinkServiceProperties("http://tmc.gov.in/ncg-gateway", 1000);
-        var link = new Link(linkServiceClient, linkRepository, clientRegistryClient, linkServiceProperties, linkResults, patientLinkReferenceResults);
+        var link = new Link(linkServiceClient, linkRepository, clientRegistryClient, linkServiceProperties, linkResults);
 
         StepVerifier.create(link.getLinkedCareContexts(patientId))
                 .expectNext(patientLinksResponse)
@@ -272,7 +269,7 @@ class LinkTest {
     @Test
     public void confirmLinkCareContexts() {
         LinkServiceProperties linkServiceProperties = new LinkServiceProperties("http://tmc.gov.in/ncg-gateway", 1000);
-        var link = new Link(linkServiceClient, linkRepository, clientRegistryClient, linkServiceProperties, linkResults, patientLinkReferenceResults);
+        var link = new Link(linkServiceClient, linkRepository, clientRegistryClient, linkServiceProperties, linkResults);
         PatientLinkRequest patientLinkRequest = patientLinkRequest().build();
         String patientId = "patient";
         String hipId = "10000005";

--- a/src/test/java/in/projecteka/consentmanager/link/link/LinkTest.java
+++ b/src/test/java/in/projecteka/consentmanager/link/link/LinkTest.java
@@ -59,6 +59,9 @@ class LinkTest {
     @Mock
     private CacheAdapter<String, String> linkResults;
 
+    @Mock
+    private CacheAdapter<String,String> patientLinkReferenceResults;
+
     @BeforeEach
     public void setUp() {
         initMocks(this);
@@ -67,7 +70,7 @@ class LinkTest {
     @Test
     public void createsLinkReference() {
         LinkServiceProperties linkServiceProperties = new LinkServiceProperties("http://tmc.gov.in/ncg-gateway", 1000);
-        var link = new Link(linkServiceClient, linkRepository, clientRegistryClient, linkServiceProperties, linkResults);
+        var link = new Link(linkServiceClient, linkRepository, clientRegistryClient, linkServiceProperties, linkResults, patientLinkReferenceResults);
         var address = address().use("work").build();
         var telecommunication = telecom().use("work").build();
         String providerUrl = "http://localhost:8001";
@@ -109,7 +112,7 @@ class LinkTest {
     public void shouldGetSystemUrlForOfficialIdentifier() {
         var token = string();
         LinkServiceProperties linkServiceProperties = new LinkServiceProperties("http://tmc.gov.in/ncg-gateway", 1000);
-        var link = new Link(linkServiceClient, linkRepository, clientRegistryClient, linkServiceProperties, linkResults);
+        var link = new Link(linkServiceClient, linkRepository, clientRegistryClient, linkServiceProperties, linkResults, patientLinkReferenceResults)
         var address = address().use("work").build();
         var telecommunication = telecom().use("work").build();
         String providerUrl = "http://localhost:8001";
@@ -156,7 +159,7 @@ class LinkTest {
     @Test
     public void shouldGetErrorWhenProviderUrlIsEmpty() {
         LinkServiceProperties linkServiceProperties = new LinkServiceProperties("http://tmc.gov.in/ncg-gateway", 1000);
-        var link = new Link(linkServiceClient, linkRepository, clientRegistryClient, linkServiceProperties, linkResults);
+        var link = new Link(linkServiceClient, linkRepository, clientRegistryClient, linkServiceProperties, linkResults, patientLinkReferenceResults);
         var address = address().use("work").build();
         var telecommunication = telecom().use("work").build();
         var provider =
@@ -188,7 +191,7 @@ class LinkTest {
     @Test
     public void linksPatientsCareContexts() {
         LinkServiceProperties linkServiceProperties = new LinkServiceProperties("http://tmc.gov.in/ncg-gateway", 1000);
-        var link = new Link(linkServiceClient, linkRepository, clientRegistryClient, linkServiceProperties, linkResults);
+        var link = new Link(linkServiceClient, linkRepository, clientRegistryClient, linkServiceProperties, linkResults, patientLinkReferenceResults);
         var address = address().use("work").build();
         var telecommunication = telecom().use("work").build();
         String providerUrl = "http://localhost:8001";
@@ -259,7 +262,7 @@ class LinkTest {
         when(linkRepository.getLinkedCareContextsForAllHip(patientId)).thenReturn(Mono.just(patientLinks));
         when(clientRegistryClient.providerWith(eq(hipId))).thenReturn(Mono.just(provider));
         LinkServiceProperties linkServiceProperties = new LinkServiceProperties("http://tmc.gov.in/ncg-gateway", 1000);
-        var link = new Link(linkServiceClient, linkRepository, clientRegistryClient, linkServiceProperties, linkResults);
+        var link = new Link(linkServiceClient, linkRepository, clientRegistryClient, linkServiceProperties, linkResults, patientLinkReferenceResults);
 
         StepVerifier.create(link.getLinkedCareContexts(patientId))
                 .expectNext(patientLinksResponse)
@@ -269,7 +272,7 @@ class LinkTest {
     @Test
     public void confirmLinkCareContexts() {
         LinkServiceProperties linkServiceProperties = new LinkServiceProperties("http://tmc.gov.in/ncg-gateway", 1000);
-        var link = new Link(linkServiceClient, linkRepository, clientRegistryClient, linkServiceProperties, linkResults);
+        var link = new Link(linkServiceClient, linkRepository, clientRegistryClient, linkServiceProperties, linkResults, patientLinkReferenceResults);
         PatientLinkRequest patientLinkRequest = patientLinkRequest().build();
         String patientId = "patient";
         String hipId = "10000005";

--- a/src/test/java/in/projecteka/consentmanager/link/link/LinkTest.java
+++ b/src/test/java/in/projecteka/consentmanager/link/link/LinkTest.java
@@ -112,7 +112,7 @@ class LinkTest {
     public void shouldGetSystemUrlForOfficialIdentifier() {
         var token = string();
         LinkServiceProperties linkServiceProperties = new LinkServiceProperties("http://tmc.gov.in/ncg-gateway", 1000);
-        var link = new Link(linkServiceClient, linkRepository, clientRegistryClient, linkServiceProperties, linkResults, patientLinkReferenceResults)
+        var link = new Link(linkServiceClient, linkRepository, clientRegistryClient, linkServiceProperties, linkResults, patientLinkReferenceResults);
         var address = address().use("work").build();
         var telecommunication = telecom().use("work").build();
         String providerUrl = "http://localhost:8001";

--- a/src/test/java/in/projecteka/consentmanager/link/link/LinkUserJourneyTest.java
+++ b/src/test/java/in/projecteka/consentmanager/link/link/LinkUserJourneyTest.java
@@ -7,6 +7,7 @@ import in.projecteka.consentmanager.DestinationsConfig;
 import in.projecteka.consentmanager.clients.model.Error;
 import in.projecteka.consentmanager.clients.model.ErrorCode;
 import in.projecteka.consentmanager.clients.model.ErrorRepresentation;
+import in.projecteka.consentmanager.clients.model.PatientLinkReferenceResult;
 import in.projecteka.consentmanager.clients.model.PatientLinkRequest;
 import in.projecteka.consentmanager.common.Authenticator;
 import in.projecteka.consentmanager.common.Caller;
@@ -16,6 +17,7 @@ import in.projecteka.consentmanager.consent.ConsentRequestNotificationListener;
 import in.projecteka.consentmanager.consent.HipConsentNotificationListener;
 import in.projecteka.consentmanager.consent.HiuConsentNotificationListener;
 import in.projecteka.consentmanager.dataflow.DataFlowBroadcastListener;
+import in.projecteka.consentmanager.link.discovery.model.patient.response.GatewayResponse;
 import in.projecteka.consentmanager.link.link.model.Hip;
 import in.projecteka.consentmanager.link.link.model.Links;
 import in.projecteka.consentmanager.link.link.model.PatientLinks;
@@ -37,6 +39,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -47,6 +50,7 @@ import reactor.core.publisher.MonoSink;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -54,6 +58,7 @@ import static in.projecteka.consentmanager.link.link.TestBuilders.errorRepresent
 import static in.projecteka.consentmanager.link.link.TestBuilders.identifier;
 import static in.projecteka.consentmanager.link.link.TestBuilders.patientLinkReferenceRequest;
 import static in.projecteka.consentmanager.link.link.TestBuilders.patientLinkReferenceResponse;
+import static in.projecteka.consentmanager.link.link.TestBuilders.patientLinkReferenceResult;
 import static in.projecteka.consentmanager.link.link.TestBuilders.patientLinkRequest;
 import static in.projecteka.consentmanager.link.link.TestBuilders.patientLinkResponse;
 import static in.projecteka.consentmanager.link.link.TestBuilders.patientRepresentation;
@@ -439,4 +444,58 @@ public class LinkUserJourneyTest {
             return new MockResponse().setResponseCode(404);
         }
     };
+
+    @Test
+    public void onLinkCareContexts() {
+        var token = string();
+        var patientLinkReferenceResult = patientLinkReferenceResult().build();
+
+        when(authenticator.verify(token)).thenReturn(Mono.just(new Caller("test-user-id@ncg", false)));
+
+        webTestClient.post()
+                .uri("/v1/links/link/on-init")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, token)
+                .bodyValue(patientLinkReferenceResult)
+                .exchange()
+                .expectStatus().isOk();
+    }
+
+    @Test
+    public void shouldFailOnLinkCareContextsWhenRequestIdIsNotGiven() throws Exception {
+        var token = string();
+        var gatewayResponse = GatewayResponse.builder()
+                .requestId(null)
+                .build();
+        var patientLinkReferenceResult = PatientLinkReferenceResult.builder()
+                .requestId(UUID.randomUUID())
+                .resp(gatewayResponse)
+                .build();
+
+        when(authenticator.verify(token)).thenReturn(Mono.just(new Caller("test-user-id@ncg", false)));
+
+        webTestClient.post()
+                .uri("/v1/links/link/on-init")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, token)
+                .bodyValue(patientLinkReferenceResult)
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+
+    @Test
+    public void shouldFailOnLinkCareContexts() throws Exception {
+        var token = string();
+        when(authenticator.verify(token)).thenReturn(Mono.just(new Caller("test-user-id@ncg", false)));
+        webTestClient.post()
+                .uri("/v1/links/link/on-init")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.AUTHORIZATION, token)
+                .exchange()
+                .expectStatus().is5xxServerError();
+    }
+
 }

--- a/src/test/java/in/projecteka/consentmanager/link/link/TestBuilders.java
+++ b/src/test/java/in/projecteka/consentmanager/link/link/TestBuilders.java
@@ -13,6 +13,7 @@ import in.projecteka.consentmanager.clients.model.PatientLinkRequest;
 import in.projecteka.consentmanager.link.link.model.PatientLinks;
 import in.projecteka.consentmanager.clients.model.PatientRepresentation;
 import in.projecteka.consentmanager.link.link.model.Links;
+import in.projecteka.consentmanager.clients.model.PatientLinkReferenceResult;
 import org.jeasy.random.EasyRandom;
 
 public class TestBuilders {
@@ -75,5 +76,9 @@ public class TestBuilders {
 
     public static String string() {
         return easyRandom.nextObject(String.class);
+    }
+
+    public static PatientLinkReferenceResult.PatientLinkReferenceResultBuilder patientLinkReferenceResult() {
+        return easyRandom.nextObject(PatientLinkReferenceResult.PatientLinkReferenceResultBuilder.class);
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -26,7 +26,7 @@ consentmanager:
     consentmanager:
       url: http://localhost:8000
   gatewayservice:
-    baseUrl: http://tmc.gov.in/ncg-gateway
+    baseUrl: http://tmc.gov.in/ncg-gateway/v1
     requestTimeout: 1000
   linkservice:
     url: http://localhost:9000


### PR DESCRIPTION
* API gets patient link reference response as request body & puts it in redis cache against the original request id.

* adds tests for the API.

* New model has been introduced for patient link reference response.