### PR TITLE
Parameterize user facing side APIs auth header

### DIFF
--- a/src/main/java/in/projecteka/consentmanager/SecurityConfiguration.java
+++ b/src/main/java/in/projecteka/consentmanager/SecurityConfiguration.java
@@ -204,7 +204,10 @@ public class SecurityConfiguration {
 
             if (isGatewayAuthenticationOnly(requestPath, requestMethod)) {
                 var token = exchange.getRequest().getHeaders().getFirst(AUTHORIZATION);
-                return checkCentralRegistry(token);
+                if (isEmpty(token)) {
+                    return Mono.empty();
+                }
+                return checkGateway(token);
             }
 
             var token = exchange.getRequest().getHeaders().getFirst(authorizationHeader);
@@ -224,7 +227,7 @@ public class SecurityConfiguration {
             return check(token);
         }
 
-        private Mono<SecurityContext> checkCentralRegistry(String token) {
+        private Mono<SecurityContext> checkGateway(String token) {
             return gatewayTokenVerifier.verify(token)
                     .map(serviceCaller -> {
                         var authorities = serviceCaller.getRoles()

--- a/src/main/java/in/projecteka/consentmanager/SecurityConfiguration.java
+++ b/src/main/java/in/projecteka/consentmanager/SecurityConfiguration.java
@@ -12,9 +12,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.ReactiveAuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -51,6 +51,7 @@ import static in.projecteka.consentmanager.link.Constants.PATH_LINK_ON_CONFIRM;
 import static in.projecteka.consentmanager.link.Constants.PATH_LINK_ON_INIT;
 import static in.projecteka.consentmanager.user.Constants.PATH_FIND_PATIENT;
 import static java.util.stream.Collectors.toList;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @Configuration
 @EnableWebFluxSecurity
@@ -79,7 +80,7 @@ public class SecurityConfiguration {
         SERVICE_ONLY_URLS.add(Map.entry("/health-information/request", HttpMethod.POST));
         SERVICE_ONLY_URLS.add(Map.entry("/consent-requests", HttpMethod.POST));
         // Deprecated
-        
+
         SERVICE_ONLY_URLS.add(Map.entry(PATH_CONSENT_REQUESTS_INIT, HttpMethod.POST));
         SERVICE_ONLY_URLS.add(Map.entry(PATH_CARE_CONTEXTS_ON_DISCOVER, HttpMethod.POST));
         SERVICE_ONLY_URLS.add(Map.entry(PATH_LINK_ON_INIT, HttpMethod.POST));
@@ -161,14 +162,17 @@ public class SecurityConfiguration {
     }
 
     @Bean
-    public SecurityContextRepository contextRepository(SignUpService signupService,
-                                                       Authenticator authenticator,
-                                                       PinVerificationTokenService pinVerificationTokenService,
-                                                       GatewayTokenVerifier gatewayTokenVerifier) {
+    public SecurityContextRepository contextRepository(
+            SignUpService signupService,
+            Authenticator authenticator,
+            PinVerificationTokenService pinVerificationTokenService,
+            GatewayTokenVerifier gatewayTokenVerifier,
+            @Value("${consentmanager.authorization.header}") String authorizationHeader) {
         return new SecurityContextRepository(signupService,
                 authenticator,
                 pinVerificationTokenService,
-                gatewayTokenVerifier);
+                gatewayTokenVerifier,
+                authorizationHeader);
     }
 
     @RequiredArgsConstructor
@@ -186,6 +190,7 @@ public class SecurityConfiguration {
         private final Authenticator identityServiceClient;
         private final PinVerificationTokenService pinVerificationTokenService;
         private final GatewayTokenVerifier gatewayTokenVerifier;
+        private final String authorizationHeader;
 
         @Override
         public Mono<Void> save(ServerWebExchange exchange, SecurityContext context) {
@@ -194,12 +199,18 @@ public class SecurityConfiguration {
 
         @Override
         public Mono<SecurityContext> load(ServerWebExchange exchange) {
-            var token = exchange.getRequest().getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+            String requestPath = exchange.getRequest().getPath().toString();
+            HttpMethod requestMethod = exchange.getRequest().getMethod();
+
+            if (isGatewayAuthenticationOnly(requestPath, requestMethod)) {
+                var token = exchange.getRequest().getHeaders().getFirst(AUTHORIZATION);
+                return checkCentralRegistry(token);
+            }
+
+            var token = exchange.getRequest().getHeaders().getFirst(authorizationHeader);
             if (isEmpty(token)) {
                 return Mono.empty();
             }
-            String requestPath = exchange.getRequest().getPath().toString();
-            HttpMethod requestMethod = exchange.getRequest().getMethod();
             if (isSignUpRequest(requestPath, requestMethod)) {
                 return checkSignUp(token);
             }
@@ -209,11 +220,6 @@ public class SecurityConfiguration {
                     return Mono.empty();//TODO handle better?
                 }
                 return validatePinVerificationRequest(token, validScope.get());
-            }
-            if (isCentralRegistryAuthenticatedOnlyRequest(
-                    requestPath,
-                    requestMethod)) {
-                return checkCentralRegistry(token);
             }
             return check(token);
         }
@@ -239,7 +245,7 @@ public class SecurityConfiguration {
                     .map(SecurityContextImpl::new);
         }
 
-        private boolean isCentralRegistryAuthenticatedOnlyRequest(String url, HttpMethod method) {
+        private boolean isGatewayAuthenticationOnly(String url, HttpMethod method) {
             AntPathMatcher antPathMatcher = new AntPathMatcher();
             return SERVICE_ONLY_URLS.stream()
                     .anyMatch(pattern ->

--- a/src/main/java/in/projecteka/consentmanager/clients/ConsentArtefactNotifier.java
+++ b/src/main/java/in/projecteka/consentmanager/clients/ConsentArtefactNotifier.java
@@ -3,9 +3,7 @@ package in.projecteka.consentmanager.clients;
 import in.projecteka.consentmanager.clients.properties.GatewayServiceProperties;
 import in.projecteka.consentmanager.consent.model.request.HIPNotificationRequest;
 import in.projecteka.consentmanager.consent.model.request.HIUNotificationRequest;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -14,6 +12,9 @@ import java.util.function.Supplier;
 
 import static in.projecteka.consentmanager.common.Constants.HDR_HIP_ID;
 import static in.projecteka.consentmanager.common.Constants.HDR_HIU_ID;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static reactor.core.publisher.Mono.error;
 
 public class ConsentArtefactNotifier {
     private final WebClient webClient;
@@ -39,21 +40,20 @@ public class ConsentArtefactNotifier {
         return postConsentArtefactToHip(notificationRequest, hipId);
     }
 
-
     private Mono<Void> postConsentArtifactToHiu(HIUNotificationRequest body, String hiuId) {
         return tokenGenerator.get()
                 .flatMap(token -> webClient
                                 .post()
                                 .uri(gatewayServiceProperties.getBaseUrl() + HIU_CONSENT_NOTIFICATION_URL_PATH)
-                                .header(HttpHeaders.AUTHORIZATION, token)
+                                .header(AUTHORIZATION, token)
                                 .header(HDR_HIU_ID, hiuId)
                                 .bodyValue(body)
                                 .retrieve()
                                 .onStatus(httpStatus -> httpStatus.value() == 401,
                                         // Error msg should be logged
-                                        clientResponse -> Mono.error(ClientError.unAuthorized()))
+                                        clientResponse -> error(ClientError.unAuthorized()))
                                 .onStatus(HttpStatus::is5xxServerError,
-                                        clientResponse -> Mono.error(ClientError.networkServiceCallFailed()))
+                                        clientResponse -> error(ClientError.networkServiceCallFailed()))
                                 .toBodilessEntity())
                 .timeout(Duration.ofMillis(gatewayServiceProperties.getRequestTimeout()))
                 .then();
@@ -64,16 +64,16 @@ public class ConsentArtefactNotifier {
                 .flatMap(token -> webClient
                                 .post()
                                 .uri(gatewayServiceProperties.getBaseUrl() + HIP_CONSENT_NOTIFICATION_URL_PATH)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .header(HttpHeaders.AUTHORIZATION, token)
+                                .contentType(APPLICATION_JSON)
+                                .header(AUTHORIZATION, token)
                                 .header(HDR_HIP_ID, hipId)
                                 .bodyValue(body)
                                 .retrieve()
                                 .onStatus(httpStatus -> httpStatus.value() == 401,
                                         // Error msg should be logged
-                                        clientResponse -> Mono.error(ClientError.unAuthorized()))
+                                        clientResponse -> error(ClientError.unAuthorized()))
                                 .onStatus(HttpStatus::is5xxServerError,
-                                        clientResponse -> Mono.error(ClientError.networkServiceCallFailed()))
+                                        clientResponse -> error(ClientError.networkServiceCallFailed()))
                                 .toBodilessEntity()
                                 .timeout(Duration.ofMillis(gatewayServiceProperties.getRequestTimeout())))
                 .then();

--- a/src/main/java/in/projecteka/consentmanager/clients/ConsentManagerClient.java
+++ b/src/main/java/in/projecteka/consentmanager/clients/ConsentManagerClient.java
@@ -80,7 +80,7 @@ public class ConsentManagerClient {
                                 .uri(gatewayServiceProperties.getBaseUrl() + CONSENT_FETCH_URL_PATH)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .header(AUTHORIZATION, token)
-                                .header("X-HIU-ID", hiuId)
+                                .header(HDR_HIU_ID, hiuId)
                                 .bodyValue(consentArtefactResult)
                                 .retrieve()
                                 .onStatus(httpStatus -> httpStatus.value() == 400,

--- a/src/main/java/in/projecteka/consentmanager/clients/PatientServiceClient.java
+++ b/src/main/java/in/projecteka/consentmanager/clients/PatientServiceClient.java
@@ -8,8 +8,6 @@ import reactor.core.publisher.Mono;
 
 import java.util.function.Supplier;
 
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-
 @AllArgsConstructor
 public class PatientServiceClient {
 
@@ -17,6 +15,7 @@ public class PatientServiceClient {
     private final WebClient webClientBuilder;
     private final Supplier<Mono<String>> tokenGenerator;
     private final String baseUrl;
+    private final String authorizationHeader;
 
     public Mono<LinkedCareContexts> retrievePatientLinks(String username) {
         return tokenGenerator.get()
@@ -24,7 +23,7 @@ public class PatientServiceClient {
                         webClientBuilder
                                 .get()
                                 .uri(String.format(INTERNAL_PATH_PATIENT_LINKS, baseUrl, username))
-                                .header(AUTHORIZATION, authorization)
+                                .header(authorizationHeader, authorization)
                                 .retrieve()
                                 .onStatus(httpStatus -> httpStatus.value() == 401,
                                         clientResponse -> Mono.error(ClientError.unAuthorized()))

--- a/src/main/java/in/projecteka/consentmanager/consent/ConsentConfiguration.java
+++ b/src/main/java/in/projecteka/consentmanager/consent/ConsentConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.amqp.core.AmqpTemplate;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -59,31 +60,37 @@ public class ConsentConfiguration {
     }
 
     @Bean
-    public ConsentManager consentRequestService(@Qualifier("customBuilder") WebClient.Builder builder,
-                                                ConsentRequestRepository repository,
-                                                UserServiceProperties userServiceProperties,
-                                                ConsentArtefactRepository consentArtefactRepository,
-                                                KeyPair keyPair,
-                                                ConsentNotificationPublisher consentNotificationPublisher,
-                                                ServiceAuthentication serviceAuthentication,
-                                                CentralRegistry centralRegistry,
-                                                PostConsentRequest postConsentRequest,
-                                                LinkServiceProperties linkServiceProperties,
-                                                IdentityService identityService,
-                                                ConceptValidator conceptValidator,
-                                                GatewayServiceProperties gatewayServiceProperties) {
+    public ConsentManager consentRequestService(
+            @Qualifier("customBuilder") WebClient.Builder builder,
+            ConsentRequestRepository repository,
+            UserServiceProperties userServiceProperties,
+            ConsentArtefactRepository consentArtefactRepository,
+            KeyPair keyPair,
+            ConsentNotificationPublisher consentNotificationPublisher,
+            ServiceAuthentication serviceAuthentication,
+            CentralRegistry centralRegistry,
+            PostConsentRequest postConsentRequest,
+            LinkServiceProperties linkServiceProperties,
+            IdentityService identityService,
+            ConceptValidator conceptValidator,
+            GatewayServiceProperties gatewayServiceProperties,
+            @Value("${consentmanager.authorization.header}") String authorizationHeader) {
         return new ConsentManager(
                 new UserServiceClient(builder.build(), userServiceProperties.getUrl(),
                         identityService::authenticate,
                         gatewayServiceProperties,
-                        serviceAuthentication),
+                        serviceAuthentication,
+                        authorizationHeader),
                 repository,
                 consentArtefactRepository,
                 keyPair,
                 consentNotificationPublisher,
                 centralRegistry,
                 postConsentRequest,
-                new PatientServiceClient(builder.build(), identityService::authenticate, linkServiceProperties.getUrl()),
+                new PatientServiceClient(builder.build(),
+                        identityService::authenticate,
+                        linkServiceProperties.getUrl(),
+                        authorizationHeader),
                 new CMProperties(gatewayServiceProperties.getClientId()),
                 conceptValidator,
                 new ConsentArtefactQueryGenerator(),
@@ -173,7 +180,8 @@ public class ConsentConfiguration {
             ConsentServiceProperties consentServiceProperties,
             IdentityService identityService,
             GatewayServiceProperties gatewayServiceProperties,
-            ServiceAuthentication serviceAuthentication) {
+            ServiceAuthentication serviceAuthentication,
+            @Value("${consentmanager.authorization.header}") String authorizationHeader) {
         return new ConsentRequestNotificationListener(
                 messageListenerContainerFactory,
                 destinationsConfig,
@@ -183,7 +191,8 @@ public class ConsentConfiguration {
                         userServiceProperties.getUrl(),
                         identityService::authenticate,
                         gatewayServiceProperties,
-                        serviceAuthentication),
+                        serviceAuthentication,
+                        authorizationHeader),
                 consentServiceProperties);
     }
 

--- a/src/main/java/in/projecteka/consentmanager/link/LinkConfiguration.java
+++ b/src/main/java/in/projecteka/consentmanager/link/LinkConfiguration.java
@@ -22,6 +22,7 @@ import in.projecteka.consentmanager.user.UserServiceProperties;
 import io.lettuce.core.RedisClient;
 import io.vertx.pgclient.PgPool;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -67,16 +68,19 @@ public class LinkConfiguration {
     }
 
     @Bean
-    public UserServiceClient userServiceClient(@Qualifier("customBuilder") WebClient.Builder builder,
-                                               UserServiceProperties userServiceProperties,
-                                               IdentityService identityService,
-                                               GatewayServiceProperties gatewayServiceProperties,
-                                               ServiceAuthentication serviceAuthentication) {
+    public UserServiceClient userServiceClient(
+            @Qualifier("customBuilder") WebClient.Builder builder,
+            UserServiceProperties userServiceProperties,
+            IdentityService identityService,
+            GatewayServiceProperties gatewayServiceProperties,
+            ServiceAuthentication serviceAuthentication,
+            @Value("${consentmanager.authorization.header}") String authorizationHeader) {
         return new UserServiceClient(builder.build(),
                 userServiceProperties.getUrl(),
                 identityService::authenticate,
                 gatewayServiceProperties,
-                serviceAuthentication);
+                serviceAuthentication,
+                authorizationHeader);
     }
 
     @Bean

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,8 @@ consentmanager:
     expiryInMinutes: ${OTP_EXPIRY_IN_MINUTES}
   jwt:
     secret: ${JWT_SECRET}
+  authorization:
+    header: ${AUTHORIZATION_HEADER:Authorization}
   keycloak:
     baseUrl: ${KEY_CLOAK_URL}
     clientId: ${KEY_CLOAK_CONSENT_CLIENT_ID}

--- a/src/test/java/in/projecteka/consentmanager/SecurityConfigurationTest.java
+++ b/src/test/java/in/projecteka/consentmanager/SecurityConfigurationTest.java
@@ -14,7 +14,6 @@ import in.projecteka.consentmanager.consent.PinVerificationTokenService;
 import in.projecteka.consentmanager.dataflow.DataFlowBroadcastListener;
 import in.projecteka.consentmanager.dataflow.DataFlowRequester;
 import in.projecteka.consentmanager.dataflow.model.HealthInfoNotificationRequest;
-import in.projecteka.consentmanager.user.Constants;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +32,7 @@ import java.util.UUID;
 import static in.projecteka.consentmanager.common.Role.GATEWAY;
 import static in.projecteka.consentmanager.common.TestBuilders.string;
 import static in.projecteka.consentmanager.dataflow.Constants.PATH_HEALTH_INFORMATION_NOTIFY;
+import static in.projecteka.consentmanager.user.Constants.PATH_FIND_PATIENT;
 import static in.projecteka.consentmanager.user.TestBuilders.patientRequest;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -94,7 +94,7 @@ class SecurityConfigurationTest {
     void return401UnAuthorized() {
         webTestClient
                 .post()
-                .uri(in.projecteka.consentmanager.user.Constants.PATH_FIND_PATIENT)
+                .uri(PATH_FIND_PATIENT)
                 .contentType(APPLICATION_JSON)
                 .bodyValue("{}")
                 .exchange()
@@ -110,7 +110,7 @@ class SecurityConfigurationTest {
 
         webTestClient
                 .post()
-                .uri(in.projecteka.consentmanager.user.Constants.PATH_FIND_PATIENT)
+                .uri(PATH_FIND_PATIENT)
                 .contentType(APPLICATION_JSON)
                 .header(AUTHORIZATION, token)
                 .bodyValue("{}")
@@ -130,7 +130,7 @@ class SecurityConfigurationTest {
 
         webTestClient
                 .post()
-                .uri(Constants.PATH_FIND_PATIENT)
+                .uri(PATH_FIND_PATIENT)
                 .contentType(APPLICATION_JSON)
                 .header(AUTHORIZATION, token)
                 .bodyValue(patientRequest)

--- a/src/test/java/in/projecteka/consentmanager/clients/PatientServiceClientTest.java
+++ b/src/test/java/in/projecteka/consentmanager/clients/PatientServiceClientTest.java
@@ -15,12 +15,12 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-import java.io.IOException;
 import java.util.Collections;
 
 import static in.projecteka.consentmanager.clients.TestBuilders.string;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 class PatientServiceClientTest {
     @Captor
@@ -36,11 +36,12 @@ class PatientServiceClientTest {
                 .exchangeFunction(exchangeFunction);
         LinkServiceProperties serviceProperties = new LinkServiceProperties("http://user-service/", 1000);
         patientServiceClient = new PatientServiceClient(webClientBuilder.build(),
-                () -> Mono.just(string()), serviceProperties.getUrl());
+                () -> Mono.just(string()), serviceProperties.getUrl(),
+                AUTHORIZATION);
     }
 
     @Test
-    void shouldGetCareContexts() throws IOException, InterruptedException {
+    void shouldGetCareContexts() {
         String patientLinkJson = "{\n" +
                 "  \"patient\": {\n" +
                 "    \"id\": \"string\",\n" +
@@ -64,8 +65,6 @@ class PatientServiceClientTest {
                 "    ]\n" +
                 "  }\n" +
                 "}";
-
-
         when(exchangeFunction.exchange(captor.capture()))
                 .thenReturn(Mono.just(ClientResponse.create(HttpStatus.OK)
                         .header("Content-Type", "application/json")

--- a/src/test/java/in/projecteka/consentmanager/clients/UserServiceClientTest.java
+++ b/src/test/java/in/projecteka/consentmanager/clients/UserServiceClientTest.java
@@ -26,8 +26,9 @@ import static in.projecteka.consentmanager.clients.TestBuilders.string;
 import static in.projecteka.consentmanager.clients.TestBuilders.user;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
-public class UserServiceClientTest {
+class UserServiceClientTest {
     @Captor
     private ArgumentCaptor<ClientRequest> captor;
     @Mock
@@ -42,23 +43,24 @@ public class UserServiceClientTest {
     void init() {
         MockitoAnnotations.initMocks(this);
         WebClient.Builder webClientBuilder = WebClient.builder().exchangeFunction(exchangeFunction);
-        var serviceProperties = new GatewayServiceProperties("http://example.com", 1000,false, "", "", "");
+        var serviceProperties = new GatewayServiceProperties("http://example.com", 1000, false, "", "", "");
         token = string();
         userServiceClient = new UserServiceClient(webClientBuilder.build(),
                 "http://user-service/",
                 () -> Mono.just(token),
                 serviceProperties,
-                serviceAuthentication);
+                serviceAuthentication,
+                AUTHORIZATION);
     }
 
     @Test
-    public void shouldGetUser() throws IOException {
+    void shouldGetUser() throws IOException {
         User user = user().name(PatientName.builder()
-                                .first("first name")
-                                .middle("")
-                                .last("")
-                                .build())
-                    .build();
+                .first("first name")
+                .middle("")
+                .last("")
+                .build())
+                .build();
         String patientResponseBody = new ObjectMapper().writeValueAsString(user);
         when(exchangeFunction.exchange(captor.capture()))
                 .thenReturn(Mono.just(ClientResponse.create(HttpStatus.OK)

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -14,6 +14,8 @@ consentmanager:
     url: http://client-registry/
   userservice:
     url: http://user-registry/
+  authorization:
+    header: Authorization
   db:
     host: localhost
     port: 5432


### PR DESCRIPTION
When we are going to PROD, our APIs will be exposed by API GATEWAY which itself expects AUTHORISATION header for first level of authentication, so we need to parameterise the USER AUTHORISATION header, so that it will be easier to deploy in PROD.

Note: gateway will still send its token in AUTHORISATION header only.

*   [x] ./gradlew bootRunLocal works
*   [x] Changed the header name to `X-AUTH-HEADER` and checked the discovery flow, it works fine end to end.